### PR TITLE
Reach 100% coverage for MCP tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,13 +204,6 @@ omit = [
     "aerospace_mcp/integrations/orbits.py",
     "aerospace_mcp/integrations/aero.py",
     "aerospace_mcp/server.py",
-    "aerospace_mcp/tools/aerodynamics.py",
-    "aerospace_mcp/tools/atmosphere.py",
-    "aerospace_mcp/tools/frames.py",
-    "aerospace_mcp/tools/optimization.py",
-    "aerospace_mcp/tools/orbits.py",
-    "aerospace_mcp/tools/propellers.py",
-    "aerospace_mcp/tools/rockets.py",
 ]
 
 [tool.coverage.report]

--- a/tests/tools/test_tools_aerodynamics.py
+++ b/tests/tools/test_tools_aerodynamics.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sys
+
+from tests.tools.test_tools_common import make_module
+
+
+def test_wing_airfoil_and_stability_success():
+    sys.modules["aerospace_mcp.integrations.aero"] = make_module(
+        wing_vlm_analysis=lambda wing, cond, opts: {
+            "aspect_ratio": 10.0,
+            "cl": 0.5,
+            "cd": 0.02,
+            "cl_cd_ratio": 25.0,
+            "lift_n": 1000.0,
+            "drag_n": 40.0,
+        },
+        airfoil_polar_analysis=lambda name, Re, M, alphas: {
+            "polar_data": [
+                {
+                    "alpha_deg": a,
+                    "cl": 0.1 * a,
+                    "cd": 0.01,
+                    "cm": -0.05,
+                    "cl_cd_ratio": 10,
+                }
+                for a in alphas
+            ]
+        },
+        calculate_stability_derivatives=lambda wing, cond: {"cm_alpha": -0.5},
+        AIRFOIL_DATABASE={"NACA0012": {"thickness": 0.12}},
+    )
+
+    from aerospace_mcp.tools.aerodynamics import (
+        airfoil_polar_analysis,
+        calculate_stability_derivatives,
+        get_airfoil_database,
+        wing_vlm_analysis,
+    )
+
+    assert "Aerodynamic" in wing_vlm_analysis({}, {}, {})
+    assert "Polar Analysis" in airfoil_polar_analysis("NACA0012")
+    assert "cm_alpha" in calculate_stability_derivatives({}, {})
+    assert "NACA0012" in get_airfoil_database()
+
+
+def test_aero_import_errors():
+    import sys
+
+    from aerospace_mcp.tools import aerodynamics as aero_tools
+
+    sys.modules["aerospace_mcp.integrations.aero"] = make_module()
+    assert "not available" in aero_tools.wing_vlm_analysis({}, {}, {}).lower()
+    assert "not available" in aero_tools.airfoil_polar_analysis("NACA0012").lower()
+    assert "not available" in aero_tools.calculate_stability_derivatives({}, {}).lower()
+    assert "not available" in aero_tools.get_airfoil_database().lower()
+
+
+def test_aero_exception_branches():
+    import sys
+
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    class Bad:
+        pass
+
+    sys.modules["aerospace_mcp.integrations.aero"] = make_module(
+        wing_vlm_analysis=_boom,
+        airfoil_polar_analysis=_boom,
+        calculate_stability_derivatives=_boom,
+        AIRFOIL_DATABASE=Bad(),
+    )
+    from aerospace_mcp.tools import aerodynamics as aero_tools
+
+    assert "error" in aero_tools.wing_vlm_analysis({}, {}, {}).lower()
+    assert "error" in aero_tools.airfoil_polar_analysis("NACA0012").lower()
+    assert "error" in aero_tools.calculate_stability_derivatives({}, {}).lower()
+    assert "error" in aero_tools.get_airfoil_database().lower()

--- a/tests/tools/test_tools_agents.py
+++ b/tests/tools/test_tools_agents.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+
+def test_agents_errors(monkeypatch):
+    import importlib
+
+    # Disabled tools
+    monkeypatch.setenv("LLM_TOOLS_ENABLED", "false")
+    import aerospace_mcp.tools.agents as agents
+
+    importlib.reload(agents)
+    format_data_for_tool = agents.format_data_for_tool
+    select_aerospace_tool = agents.select_aerospace_tool
+
+    assert (
+        "disabled" in format_data_for_tool("search_airports", "plan a flight").lower()
+    )
+    assert "disabled" in select_aerospace_tool("plan a flight").lower()
+
+    # Enabled but missing key
+    monkeypatch.setenv("LLM_TOOLS_ENABLED", "true")
+    import importlib
+
+    import aerospace_mcp.tools.agents as agents2
+
+    importlib.reload(agents2)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert "not set" in agents2.format_data_for_tool("search_airports", "plan").lower()
+    assert "not set" in agents2.select_aerospace_tool("plan").lower()
+
+
+def test_agents_success(monkeypatch):
+    import importlib
+
+    monkeypatch.setenv("LLM_TOOLS_ENABLED", "true")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    class Choice:
+        class Msg:
+            content = '{"tool": "search_airports"}'
+
+        message = Msg()
+
+    class Resp:
+        choices = [Choice()]
+
+    # Patch litellm.completion
+    import aerospace_mcp.tools.agents as agents
+
+    importlib.reload(agents)
+
+    class StubLLM:
+        def completion(self, *a, **k):
+            return Resp()
+
+    agents.litellm = StubLLM()  # type: ignore
+
+    out = agents.format_data_for_tool("search_airports", "Find airports in San Jose")
+    assert "search_airports" in out
+
+
+def test_agents_exception_paths(monkeypatch):
+    import importlib
+
+    import aerospace_mcp.tools.agents as agents
+
+    monkeypatch.setenv("LLM_TOOLS_ENABLED", "true")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    importlib.reload(agents)
+
+    class BadLLM:
+        def completion(self, *a, **k):
+            raise RuntimeError("boom")
+
+    agents.litellm = BadLLM()  # type: ignore
+    assert "error" in agents.format_data_for_tool("search_airports", "task").lower()
+    assert "error" in agents.select_aerospace_tool("task").lower()
+
+
+def test_select_tool_success(monkeypatch):
+    import importlib
+
+    import aerospace_mcp.tools.agents as agents
+
+    monkeypatch.setenv("LLM_TOOLS_ENABLED", "true")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    importlib.reload(agents)
+
+    class Choice:
+        class Msg:
+            content = "PRIMARY_TOOL: search_airports\\nWORKFLOW: ..."
+
+        message = Msg()
+
+    class Resp:
+        choices = [Choice()]
+
+    class StubLLM:
+        def completion(self, *a, **k):
+            return Resp()
+
+    agents.litellm = StubLLM()  # type: ignore
+    out = agents.select_aerospace_tool("Find airports in San Jose")
+    assert "PRIMARY_TOOL" in out
+
+
+def test_format_data_invalid_json(monkeypatch):
+    import importlib
+
+    import aerospace_mcp.tools.agents as agents
+
+    monkeypatch.setenv("LLM_TOOLS_ENABLED", "true")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    importlib.reload(agents)
+
+    class Choice:
+        class Msg:
+            content = "not json"
+
+        message = Msg()
+
+    class Resp:
+        choices = [Choice()]
+
+    class StubLLM:
+        def completion(self, *a, **k):
+            return Resp()
+
+    agents.litellm = StubLLM()  # type: ignore
+    out = agents.format_data_for_tool("search_airports", "Find airports")
+    assert "failed to generate valid json" in out.lower()

--- a/tests/tools/test_tools_atmosphere.py
+++ b/tests/tools/test_tools_atmosphere.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sys
+
+from tests.tools.test_tools_common import StubModel, make_module
+
+
+def test_get_atmosphere_profile_success(monkeypatch):
+    def _get_profile(alts, model):
+        return [
+            StubModel(
+                altitude_m=a,
+                pressure_pa=101325 - a,
+                temperature_k=288.15 - 0.0065 * a,
+                density_kg_m3=1.225,
+                speed_of_sound_mps=340.0,
+            )
+            for a in alts
+        ]
+
+    mod = make_module(get_atmosphere_profile=_get_profile)
+    sys.modules["aerospace_mcp.integrations.atmosphere"] = mod
+
+    from aerospace_mcp.tools.atmosphere import get_atmosphere_profile
+
+    out = get_atmosphere_profile([0, 1000], "ISA")
+    assert "Atmospheric Profile" in out
+    assert "JSON Data:" in out
+
+
+def test_get_atmosphere_profile_importerror(monkeypatch):
+    import sys as _sys
+
+    _sys.modules["aerospace_mcp.integrations.atmosphere"] = make_module()
+    from aerospace_mcp.tools.atmosphere import get_atmosphere_profile
+
+    out = get_atmosphere_profile([0], "ISA")
+    assert "not available" in out.lower()
+
+
+def test_wind_model_simple_success():
+    def _wind_model(*args, **kwargs):
+        return [
+            StubModel(
+                altitude_m=a,
+                wind_speed_ms=5.0 + i,
+                wind_direction_deg=270.0,
+                gust_factor=1.0,
+            )
+            for i, a in enumerate([0.0, 50.0])
+        ]
+
+    sys.modules["aerospace_mcp.integrations.atmosphere"] = make_module(
+        wind_model_simple=_wind_model
+    )
+
+    from aerospace_mcp.tools.atmosphere import wind_model_simple
+
+    out = wind_model_simple([0.0, 50.0])
+    assert "Wind Profile" in out
+
+
+def test_atmosphere_exception_handling(monkeypatch):
+    import sys as _sys
+
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    _sys.modules["aerospace_mcp.integrations.atmosphere"] = make_module(
+        get_atmosphere_profile=_boom, wind_model_simple=_boom
+    )
+    from aerospace_mcp.tools.atmosphere import (
+        get_atmosphere_profile as _gp,
+    )
+    from aerospace_mcp.tools.atmosphere import (
+        wind_model_simple as _wm,
+    )
+
+    assert "error" in _gp([0]).lower()
+    assert "error" in _wm([0.0]).lower()
+
+
+def test_wind_model_simple_importerror():
+    import sys as _sys
+
+    _sys.modules["aerospace_mcp.integrations.atmosphere"] = make_module()
+    from aerospace_mcp.tools.atmosphere import wind_model_simple
+
+    out = wind_model_simple([0.0])
+    assert "not available" in out.lower()

--- a/tests/tools/test_tools_common.py
+++ b/tests/tools/test_tools_common.py
@@ -1,0 +1,70 @@
+"""Common stubs and helpers for testing MCP tools modules.
+
+These helpers allow simulating the integrations modules without installing
+heavy optional dependencies, while covering success and error branches.
+"""
+
+from __future__ import annotations
+
+import builtins
+import types
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+
+class StubModel:
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+    def model_dump(self) -> dict[str, Any]:
+        return dict(self.__dict__)
+
+
+@dataclass
+class StubPerf:
+    max_altitude_m: float = 1000.0
+    max_velocity_ms: float = 100.0
+    max_mach: float = 0.3
+    apogee_time_s: float = 50.0
+    burnout_time_s: float = 10.0
+    max_q_pa: float = 12_000.0
+    total_impulse_ns: float = 100_000.0
+    specific_impulse_s: float = 250.0
+
+
+@dataclass
+class StubPoint:
+    time_s: float = 0.0
+    altitude_m: float = 0.0
+    velocity_ms: float = 0.0
+    acceleration_ms2: float = 0.0
+
+
+@contextmanager
+def import_raising(module_glob: str):
+    """Context manager to make imports of a module raise ImportError.
+
+    Args:
+        module_glob: Substring to match in module import name.
+    """
+
+    original_import = builtins.__import__
+
+    def raising_import(name: str, *args: Any, **kwargs: Any):  # type: ignore[override]
+        if module_glob in name:
+            raise ImportError(f"forced import error for {name}")
+        return original_import(name, *args, **kwargs)
+
+    builtins.__import__ = raising_import  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        builtins.__import__ = original_import  # type: ignore[assignment]
+
+
+def make_module(**members: Any) -> types.ModuleType:
+    mod = types.ModuleType("stub_module")
+    for k, v in members.items():
+        setattr(mod, k, v)
+    return mod

--- a/tests/tools/test_tools_core_tools.py
+++ b/tests/tools/test_tools_core_tools.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+
+import aerospace_mcp.tools.core as core_tools
+
+
+def test_search_airports_and_distance(monkeypatch):
+    class A:
+        def __init__(self, iata: str):
+            self.iata = iata
+            self.icao = "K" + iata
+            self.name = "Name"
+            self.city = "City"
+            self.country = "US"
+            self.lat = 0.0
+            self.lon = 0.0
+            self.tz = None
+
+    monkeypatch.setattr(
+        core_tools, "_airport_from_iata", lambda q: A(q) if q.upper() == "SJC" else None
+    )
+    monkeypatch.setattr(
+        core_tools,
+        "_find_city_airports",
+        lambda q, c: [A("SJC")] if q.lower() == "san jose" else [],
+    )
+
+    out = core_tools.search_airports("SJC", "US", "auto")
+    assert "Found" in out
+    out2 = core_tools.search_airports("Unknown", "US", "city")
+    assert "No airports" in out2
+    out3 = core_tools.search_airports("  ")
+    assert "required" in out3
+
+    # calculate_distance expects great_circle_points providing mapping
+    monkeypatch.setattr(
+        core_tools,
+        "great_circle_points",
+        lambda a, b, c, d, step_km: {
+            "distance_km": 1000.0,
+            "distance_nm": 539.9,
+            "initial_bearing_deg": 10.0,
+            "final_bearing_deg": 20.0,
+        },
+    )
+    dist = core_tools.calculate_distance(0, 0, 1, 1)
+    data = json.loads(dist)
+    assert data["distance_km"] == 1000.0
+
+
+def test_plan_and_status(monkeypatch):
+    # Stubs for endpoints and routing
+    class A:
+        def __init__(self, iata: str):
+            self.iata = iata
+            self.icao = "K" + iata
+            self.name = "Name"
+            self.city = "City"
+            self.country = "US"
+            self.lat = 0.0
+            self.lon = 0.0
+            self.tz = None
+
+    monkeypatch.setattr(
+        core_tools,
+        "_resolve_endpoint",
+        lambda city, country, iata=None: A(iata or "SJC"),
+    )
+    monkeypatch.setattr(
+        core_tools,
+        "great_circle_points",
+        lambda a, b, c, d, step_km: {
+            "distance_km": 1000.0,
+            "distance_nm": 539.9,
+            "initial_bearing_deg": 10.0,
+            "final_bearing_deg": 20.0,
+            "points": [(0.0, 0.0, 0.0)],
+        },
+    )
+    # estimates_openap may not be available; return simple tuple
+    monkeypatch.setattr(core_tools, "OPENAP_AVAILABLE", True)
+    monkeypatch.setattr(
+        core_tools,
+        "estimates_openap",
+        lambda *a, **k: (
+            {"assumptions": {"cruise_alt_ft": a[1], "mass_kg": 70000.0}},
+            "engine",
+        ),
+    )
+
+    out = core_tools.plan_flight(
+        {"city": "City", "iata": "SJC"},
+        {"city": "City", "iata": "NRT"},
+        {"ac_type": "A320", "cruise_alt_ft": 41000, "route_step_km": 25.0},
+        {},
+    )
+    data = json.loads(out)
+    assert data["route"]["distance_km"] == 1000.0
+
+    status = core_tools.get_system_status()
+    assert "system" in status
+
+
+def test_plan_optional_fields_and_resolution_error(monkeypatch):
+    import aerospace_mcp.tools.core as core_tools
+    from aerospace_mcp.core import AirportResolutionError
+
+    # Resolution error path
+    def raise_res(*a, **k):
+        raise AirportResolutionError("nope")
+
+    monkeypatch.setattr(core_tools, "_resolve_endpoint", raise_res)
+    out_err = core_tools.plan_flight(
+        {"city": "City", "country": "US"},
+        {"city": "City", "country": "JP"},
+        {"ac_type": "A320"},
+    )
+    assert "Airport resolution error" in out_err
+
+    # Optional fields executed (with successful resolve)
+    class A:
+        def __init__(self, iata: str, country: str):
+            self.iata = iata
+            self.icao = "K" + iata
+            self.name = "Name"
+            self.city = "City"
+            self.country = country
+            self.lat = 0.0
+            self.lon = 0.0
+            self.tz = None
+
+    monkeypatch.setattr(
+        core_tools,
+        "_resolve_endpoint",
+        lambda city, country, iata=None: A(iata or "SJC", country or "US"),
+    )
+    monkeypatch.setattr(
+        core_tools,
+        "great_circle_points",
+        lambda *a, **k: {
+            "distance_km": 1.0,
+            "distance_nm": 1.0,
+            "initial_bearing_deg": 0.0,
+            "final_bearing_deg": 0.0,
+            "points": [(0, 0, 0)],
+        },
+    )
+    out_ok = core_tools.plan_flight(
+        {"city": "City", "country": "US"},
+        {"city": "City", "country": "JP"},
+        {"ac_type": "A320"},
+    )
+    assert "departure" in out_ok
+
+
+def test_search_airports_exception(monkeypatch):
+    import aerospace_mcp.tools.core as core_tools
+
+    def boom(q):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(core_tools, "_airport_from_iata", boom)
+    out = core_tools.search_airports("SJC", None, "iata")
+    assert "Search error" in out
+
+
+def test_plan_invalid_request(monkeypatch):
+    import aerospace_mcp.tools.core as core_tools
+
+    # Valid endpoints
+    class A:
+        def __init__(self, iata: str):
+            self.iata = iata
+            self.icao = "K" + iata
+            self.name = "Name"
+            self.city = "City"
+            self.country = "US"
+            self.lat = 0.0
+            self.lon = 0.0
+            self.tz = None
+
+    monkeypatch.setattr(core_tools, "_resolve_endpoint", lambda *a, **k: A("SJC"))
+    # Build invalid PlanRequest by negative route_step_km
+    out = core_tools.plan_flight(
+        {"city": "City"},
+        {"city": "City"},
+        {"ac_type": "A320", "route_step_km": -1.0},
+    )
+    assert "Invalid request" in out
+
+
+def test_plan_openap_error_and_unavailable(monkeypatch):
+    import aerospace_mcp.tools.core as core_tools
+
+    class A:
+        def __init__(self, iata: str):
+            self.iata = iata
+            self.icao = "K" + iata
+            self.name = "Name"
+            self.city = "City"
+            self.country = "US"
+            self.lat = 0.0
+            self.lon = 0.0
+            self.tz = None
+
+    monkeypatch.setattr(core_tools, "_resolve_endpoint", lambda *a, **k: A("SJC"))
+    monkeypatch.setattr(
+        core_tools,
+        "great_circle_points",
+        lambda *a, **k: {
+            "distance_km": 1.0,
+            "distance_nm": 1.0,
+            "initial_bearing_deg": 0.0,
+            "final_bearing_deg": 0.0,
+            "points": [(0, 0, 0)],
+        },
+    )
+    # OpenAP available but raises
+    monkeypatch.setattr(core_tools, "OPENAP_AVAILABLE", True)
+    from aerospace_mcp.core import OpenAPError
+
+    def raise_openap(*a, **k):
+        raise OpenAPError("bad")
+
+    monkeypatch.setattr(core_tools, "estimates_openap", raise_openap)
+    out = core_tools.plan_flight(
+        {"city": "City"}, {"city": "City"}, {"ac_type": "A320"}
+    )
+    assert "Performance estimation failed" in out
+    # OpenAP unavailable path
+    monkeypatch.setattr(core_tools, "OPENAP_AVAILABLE", False)
+    out2 = core_tools.plan_flight(
+        {"city": "City"}, {"city": "City"}, {"ac_type": "A320"}
+    )
+    assert "OpenAP not available" in out2
+
+
+def test_plan_and_distance_exception(monkeypatch):
+    import aerospace_mcp.tools.core as core_tools
+
+    def boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(core_tools, "great_circle_points", boom)
+    out = core_tools.plan_flight(
+        {"city": "City"}, {"city": "City"}, {"ac_type": "A320"}
+    )
+    assert "Flight planning error" in out
+    out2 = core_tools.calculate_distance(0, 0, 0, 0)
+    assert "Distance calculation error" in out2
+
+
+def test_get_aircraft_performance_branches(monkeypatch):
+    import aerospace_mcp.tools.core as core_tools
+
+    # Unavailable
+    monkeypatch.setattr(core_tools, "OPENAP_AVAILABLE", False)
+    assert "OpenAP library is not available" in core_tools.get_aircraft_performance(
+        "A320", 1000
+    )
+    # Available success
+    monkeypatch.setattr(core_tools, "OPENAP_AVAILABLE", True)
+    monkeypatch.setattr(core_tools, "estimates_openap", lambda *a, **k: {"ok": True})
+    assert "ok" in core_tools.get_aircraft_performance("A320", 1000)
+    # OpenAPError
+    from aerospace_mcp.core import OpenAPError
+
+    def raise_openap(*a, **k):
+        raise OpenAPError("bad")
+
+    monkeypatch.setattr(core_tools, "estimates_openap", raise_openap)
+    assert "Performance estimation error" in core_tools.get_aircraft_performance(
+        "A320", 1000
+    )
+    # Unexpected error
+    monkeypatch.setattr(
+        core_tools,
+        "estimates_openap",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    assert "Unexpected error" in core_tools.get_aircraft_performance("A320", 1000)
+
+
+def test_system_status_openap_false(monkeypatch):
+    import aerospace_mcp.tools.core as core_tools
+
+    monkeypatch.setattr(core_tools, "OPENAP_AVAILABLE", False)
+    out = core_tools.get_system_status()
+    assert "OpenAP not available" in out

--- a/tests/tools/test_tools_frames.py
+++ b/tests/tools/test_tools_frames.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sys
+
+from tests.tools.test_tools_common import make_module
+
+
+def test_transform_frames_success():
+    def _transform(coords, from_f, to_f, epoch):
+        return {"ok": True, "from": from_f, "to": to_f, "coords": coords}
+
+    sys.modules["aerospace_mcp.integrations.frames"] = make_module(
+        transform_frames=_transform
+    )
+    from aerospace_mcp.tools.frames import transform_frames
+
+    out = transform_frames({"x": 1}, "ECEF", "ECI", None)
+    assert "ok" in out
+
+
+def test_transform_frames_importerror():
+    import sys as _sys
+
+    _sys.modules["aerospace_mcp.integrations.frames"] = make_module()
+    from aerospace_mcp.tools.frames import transform_frames
+
+    out = transform_frames({}, "ECEF", "ECI", None)
+    assert "not available" in out.lower()
+
+
+def test_geodetic_to_ecef_success():
+    sys.modules["aerospace_mcp.integrations.frames"] = make_module(
+        geodetic_to_ecef=lambda lat, lon, alt: {"x_m": 1.0, "y_m": 2.0, "z_m": 3.0}
+    )
+    from aerospace_mcp.tools.frames import geodetic_to_ecef
+
+    out = geodetic_to_ecef(0, 0, 0)
+    assert "ECEF" in out
+
+
+def test_geodetic_to_ecef_importerror():
+    import sys as _sys
+
+    _sys.modules["aerospace_mcp.integrations.frames"] = make_module()
+    from aerospace_mcp.tools.frames import geodetic_to_ecef
+
+    out = geodetic_to_ecef(0, 0, 0)
+    assert "not available" in out.lower()
+
+
+def test_ecef_to_geodetic_success():
+    sys.modules["aerospace_mcp.integrations.frames"] = make_module(
+        ecef_to_geodetic=lambda x, y, z: {
+            "latitude_deg": 0.0,
+            "longitude_deg": 0.0,
+            "altitude_m": 0.0,
+        }
+    )
+    from aerospace_mcp.tools.frames import ecef_to_geodetic
+
+    out = ecef_to_geodetic(1, 2, 3)
+    assert "Geodetic" in out
+
+
+def test_frames_exception_branches():
+    import sys as _sys
+
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    _sys.modules["aerospace_mcp.integrations.frames"] = make_module(
+        transform_frames=_boom, geodetic_to_ecef=_boom, ecef_to_geodetic=_boom
+    )
+    from aerospace_mcp.tools.frames import (
+        ecef_to_geodetic as _e2g,
+    )
+    from aerospace_mcp.tools.frames import (
+        geodetic_to_ecef as _g2e,
+    )
+    from aerospace_mcp.tools.frames import (
+        transform_frames as _tf,
+    )
+
+    assert "error" in _tf({}, "ECEF", "ECI", None).lower()
+    assert "error" in _g2e(0, 0, 0).lower()
+    assert "error" in _e2g(0, 0, 0).lower()
+
+
+def test_ecef_to_geodetic_importerror():
+    import sys as _sys
+
+    _sys.modules["aerospace_mcp.integrations.frames"] = make_module()
+    from aerospace_mcp.tools.frames import ecef_to_geodetic
+
+    out = ecef_to_geodetic(0, 0, 0)
+    assert "not available" in out.lower()

--- a/tests/tools/test_tools_optimization.py
+++ b/tests/tools/test_tools_optimization.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import sys
+
+from tests.tools.test_tools_common import StubPerf, make_module
+
+
+class RocketGeometry:
+    def __init__(self, **kwargs):
+        pass
+
+
+def test_optimization_success():
+    class OptResult:
+        optimization_result = "ok"
+        optimal_objective = 1.0
+        optimal_parameters = {"a": 1}
+        performance = StubPerf()
+
+    sys.modules["aerospace_mcp.integrations.trajopt"] = make_module(
+        RocketGeometry=RocketGeometry,
+        optimize_thrust_profile=lambda *a, **k: OptResult(),
+        trajectory_sensitivity_analysis=lambda *a, **k: {"sensitivity": []},
+        genetic_algorithm_optimization=lambda *a, **k: {"ga": True},
+        particle_swarm_optimization=lambda *a, **k: {"pso": True},
+        porkchop_plot_analysis=lambda *a, **k: {"porkchop": True},
+        monte_carlo_uncertainty_analysis=lambda *a, **k: {"mc": True},
+    )
+
+    from aerospace_mcp.tools.optimization import (
+        genetic_algorithm_optimization,
+        monte_carlo_uncertainty_analysis,
+        optimize_thrust_profile,
+        particle_swarm_optimization,
+        porkchop_plot_analysis,
+        trajectory_sensitivity_analysis,
+    )
+
+    assert "optimization_result" in optimize_thrust_profile({}, 10, 1000)
+    assert "sensitivity" in trajectory_sensitivity_analysis({}, {})
+    assert "ga" in genetic_algorithm_optimization({})
+    assert "pso" in particle_swarm_optimization({})
+    assert "porkchop" in porkchop_plot_analysis(
+        "Earth", "Mars", ["2025-01-01"], ["2025-12-01"]
+    )
+    assert "mc" in monte_carlo_uncertainty_analysis({}, {}, 10)
+
+
+def test_optimization_import_errors():
+    import sys
+
+    from aerospace_mcp.tools import optimization as opt_tools
+
+    sys.modules["aerospace_mcp.integrations.trajopt"] = make_module()
+    assert "not available" in opt_tools.optimize_thrust_profile({}, 1.0, 1.0).lower()
+    assert "not available" in opt_tools.trajectory_sensitivity_analysis({}, {}).lower()
+    assert "not available" in opt_tools.genetic_algorithm_optimization({}).lower()
+    assert "not available" in opt_tools.particle_swarm_optimization({}).lower()
+    assert "not available" in opt_tools.porkchop_plot_analysis("A", "B", [], []).lower()
+    assert (
+        "not available" in opt_tools.monte_carlo_uncertainty_analysis({}, {}, 1).lower()
+    )
+
+
+def test_optimization_exception_branches():
+    import sys
+
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    sys.modules["aerospace_mcp.integrations.trajopt"] = make_module(
+        RocketGeometry=type("R", (), {}),
+        optimize_thrust_profile=_boom,
+        trajectory_sensitivity_analysis=_boom,
+        genetic_algorithm_optimization=_boom,
+        particle_swarm_optimization=_boom,
+        porkchop_plot_analysis=_boom,
+        monte_carlo_uncertainty_analysis=_boom,
+    )
+    from aerospace_mcp.tools import optimization as opt
+
+    assert "error" in opt.optimize_thrust_profile({}, 1.0, 1.0).lower()
+    assert "error" in opt.trajectory_sensitivity_analysis({}, {}).lower()
+    assert "error" in opt.genetic_algorithm_optimization({}).lower()
+    assert "error" in opt.particle_swarm_optimization({}).lower()
+    assert "error" in opt.porkchop_plot_analysis("A", "B", [], []).lower()
+    assert "error" in opt.monte_carlo_uncertainty_analysis({}, {}, 1).lower()

--- a/tests/tools/test_tools_orbits.py
+++ b/tests/tools/test_tools_orbits.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import sys
+
+from tests.tools.test_tools_common import make_module
+
+
+class OrbitElements:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class StateVector:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def test_orbits_elements_to_state_success():
+    class Result:
+        position_m = [1.0, 2.0, 3.0]
+        velocity_ms = [4.0, 5.0, 6.0]
+
+    sys.modules["aerospace_mcp.integrations.orbits"] = make_module(
+        OrbitElements=OrbitElements, elements_to_state_vector=lambda e: Result()
+    )
+    from aerospace_mcp.tools.orbits import elements_to_state_vector
+
+    out = elements_to_state_vector({"semi_major_axis_m": 7000e3})
+    assert "position_m" in out
+
+
+def test_orbits_state_to_elements_success():
+    class Result:
+        semi_major_axis_m = 1.0
+        eccentricity = 0.1
+        inclination_deg = 45.0
+        raan_deg = 0.0
+        arg_perigee_deg = 0.0
+        true_anomaly_deg = 0.0
+        epoch_utc = "2020-01-01T00:00:00Z"
+
+    sys.modules["aerospace_mcp.integrations.orbits"] = make_module(
+        StateVector=StateVector, state_vector_to_elements=lambda s: Result()
+    )
+    from aerospace_mcp.tools.orbits import state_vector_to_elements
+
+    out = state_vector_to_elements(
+        {"position_m": [1, 0, 0], "velocity_ms": [0, 1, 0], "epoch_utc": "..."}
+    )
+    assert "eccentricity" in out
+
+
+def test_orbits_propagate_and_groundtrack_success():
+    sys.modules["aerospace_mcp.integrations.orbits"] = make_module(
+        propagate_orbit_j2=lambda *a, **k: {"ok": True},
+        calculate_ground_track=lambda *a, **k: {"points": []},
+        hohmann_transfer=lambda *a, **k: {"dv": [1.0, 2.0]},
+        orbital_rendezvous_planning=lambda *a, **k: {"plan": []},
+        OrbitElements=OrbitElements,
+    )
+    from aerospace_mcp.tools.orbits import (
+        calculate_ground_track,
+        hohmann_transfer,
+        orbital_rendezvous_planning,
+        propagate_orbit_j2,
+    )
+
+    assert "ok" in propagate_orbit_j2({"state": 1}, 10.0)
+    assert "points" in calculate_ground_track({"state": 1}, 10.0)
+    assert "dv" in hohmann_transfer(7000e3, 8000e3)
+    assert "plan" in orbital_rendezvous_planning({}, {})
+
+
+def test_orbits_import_errors():
+    import sys
+
+    from aerospace_mcp.tools import orbits as orbits_tools
+
+    sys.modules["aerospace_mcp.integrations.orbits"] = make_module()
+    assert "not available" in orbits_tools.elements_to_state_vector({}).lower()
+    assert "not available" in orbits_tools.state_vector_to_elements({}).lower()
+    assert "not available" in orbits_tools.propagate_orbit_j2({}, 10.0).lower()
+    assert "not available" in orbits_tools.calculate_ground_track({}, 10.0).lower()
+    assert "not available" in orbits_tools.hohmann_transfer(1.0, 2.0).lower()
+    assert "not available" in orbits_tools.orbital_rendezvous_planning({}, {}).lower()
+
+
+def test_orbits_exception_branches():
+    import sys
+
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    sys.modules["aerospace_mcp.integrations.orbits"] = make_module(
+        OrbitElements=OrbitElements,
+        StateVector=StateVector,
+        elements_to_state_vector=_boom,
+        state_vector_to_elements=_boom,
+        propagate_orbit_j2=_boom,
+        calculate_ground_track=_boom,
+        hohmann_transfer=_boom,
+        orbital_rendezvous_planning=_boom,
+    )
+    from aerospace_mcp.tools import orbits as otools
+
+    assert "error" in otools.elements_to_state_vector({}).lower()
+    assert "error" in otools.state_vector_to_elements({}).lower()
+    assert "error" in otools.propagate_orbit_j2({}, 10.0).lower()
+    assert "error" in otools.calculate_ground_track({}, 10.0).lower()
+    assert "error" in otools.hohmann_transfer(1.0, 2.0).lower()
+    assert "error" in otools.orbital_rendezvous_planning({}, {}).lower()

--- a/tests/tools/test_tools_propellers.py
+++ b/tests/tools/test_tools_propellers.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import sys
+
+from tests.tools.test_tools_common import StubModel, make_module
+
+
+class PropellerGeometry:
+    def __init__(self, **kwargs):
+        self.diameter_m = kwargs.get("diameter_m", 0.3)
+        self.pitch_m = kwargs.get("pitch_m", 0.2)
+        self.num_blades = kwargs.get("num_blades", 2)
+
+
+def test_propeller_and_uav_success():
+    def _bemt(geom, rpm_list, vel, alt):
+        return [
+            StubModel(
+                rpm=rpm,
+                thrust_n=10.0,
+                torque_nm=1.0,
+                power_w=100.0,
+                efficiency=0.8,
+                advance_ratio=0.5,
+                thrust_coefficient=0.1,
+                power_coefficient=0.05,
+            )
+            for rpm in rpm_list
+        ]
+
+    class UAVConfig:
+        def __init__(self, **kw):
+            self.mass_kg = kw.get("mass_kg", 5.0)
+            self.wing_area_m2 = kw.get("wing_area_m2", 1.0)
+            self.disk_area_m2 = kw.get("disk_area_m2", 0.0)
+
+    class Battery:
+        def __init__(self, **kw):
+            self.capacity_ah = kw.get("capacity_ah", 10.0)
+            self.voltage_nominal_v = kw.get("voltage_nominal_v", 22.2)
+            self.mass_kg = kw.get("mass_kg", 1.0)
+
+    class EnergyResult:
+        flight_time_min = 30.0
+        range_km = 10.0
+        hover_time_min = None
+        power_required_w = 200.0
+        energy_consumed_wh = 300.0
+        battery_energy_wh = 400.0
+        efficiency_overall = 0.8
+
+    sys.modules["aerospace_mcp.integrations.propellers"] = make_module(
+        PropellerGeometry=PropellerGeometry,
+        propeller_bemt_analysis=_bemt,
+        UAVConfiguration=UAVConfig,
+        BatteryConfiguration=Battery,
+        uav_energy_estimate=lambda *a, **k: EnergyResult(),
+        PROPELLER_DATABASE={"APC_10x4.7": {"diameter": 0.254}},
+    )
+
+    from aerospace_mcp.tools.propellers import (
+        get_propeller_database,
+        propeller_bemt_analysis,
+        uav_energy_estimate,
+    )
+
+    assert "BEMT Analysis" in propeller_bemt_analysis(
+        {"diameter_m": 0.3, "pitch_m": 0.2, "num_blades": 2},
+        {"rpm_list": [2000, 3000], "velocity_ms": 20.0, "altitude_m": 0.0},
+        {},
+    )
+    assert "UAV Energy" in uav_energy_estimate(
+        {"mass_kg": 5.0, "wing_area_m2": 1.0},
+        {"capacity_ah": 10.0, "voltage_nominal_v": 22.2, "mass_kg": 1.0},
+        {},
+    )
+    assert "APC_10x4.7" in get_propeller_database()
+
+
+def test_propellers_import_errors():
+    import sys
+
+    from aerospace_mcp.tools import propellers as prop_tools
+
+    sys.modules["aerospace_mcp.integrations.propellers"] = make_module()
+    assert "not available" in prop_tools.propeller_bemt_analysis({}, {}, {}).lower()
+    assert "not available" in prop_tools.uav_energy_estimate({}, {}).lower()
+    assert "not available" in prop_tools.get_propeller_database().lower()
+
+
+def test_propellers_exception_branches():
+    import sys
+
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    sys.modules["aerospace_mcp.integrations.propellers"] = make_module(
+        PropellerGeometry=PropellerGeometry,
+        propeller_bemt_analysis=_boom,
+        UAVConfiguration=type("U", (), {}),
+        BatteryConfiguration=type("B", (), {}),
+        uav_energy_estimate=_boom,
+        PROPELLER_DATABASE={"x": 1},
+    )
+    from aerospace_mcp.tools import propellers as ptools
+
+    assert "error" in ptools.propeller_bemt_analysis({}, {}, {}).lower()
+    assert "error" in ptools.uav_energy_estimate({}, {}).lower()
+
+    # Force exception via database access
+    class BadDB:
+        def __iter__(self):
+            raise RuntimeError("boom")
+
+    sys.modules["aerospace_mcp.integrations.propellers"] = make_module(
+        PROPELLER_DATABASE=BadDB()
+    )
+    assert "error" in ptools.get_propeller_database().lower()
+
+
+def test_uav_energy_recommendations_branches():
+    import sys
+
+    class UAV:
+        def __init__(self, **kw):
+            self.mass_kg = 5.0
+            self.wing_area_m2 = kw.get("wing_area_m2", 1.0)
+            self.disk_area_m2 = kw.get("disk_area_m2", 0.0)
+
+    class Bat:
+        def __init__(self, **kw):
+            self.capacity_ah = 10.0
+            self.voltage_nominal_v = 22.2
+            self.mass_kg = 1.0
+
+    # Case: very short (<10) and low efficiency
+    class R1:
+        flight_time_min = 5.0
+        range_km = None
+        hover_time_min = 2.0
+        power_required_w = 100
+        energy_consumed_wh = 100
+        battery_energy_wh = 200
+        efficiency_overall = 0.5
+
+    # Case: short (<20)
+    class R2(R1):
+        flight_time_min = 15.0
+        efficiency_overall = 0.9
+
+    # Case: excellent (>120)
+    class R3(R1):
+        flight_time_min = 130.0
+        efficiency_overall = 0.9
+
+    sys.modules["aerospace_mcp.integrations.propellers"] = make_module(
+        UAVConfiguration=UAV,
+        BatteryConfiguration=Bat,
+        uav_energy_estimate=lambda *a, **k: R1(),
+    )
+    from aerospace_mcp.tools.propellers import uav_energy_estimate as uav
+
+    out1 = uav(
+        {"wing_area_m2": 1.0},
+        {"capacity_ah": 10.0, "voltage_nominal_v": 22.2, "mass_kg": 1.0},
+    )
+    assert "Very short" in out1
+    assert "Low system efficiency" in out1
+
+    sys.modules["aerospace_mcp.integrations.propellers"] = make_module(
+        UAVConfiguration=UAV,
+        BatteryConfiguration=Bat,
+        uav_energy_estimate=lambda *a, **k: R2(),
+    )
+    out2 = uav(
+        {"wing_area_m2": 1.0},
+        {"capacity_ah": 10.0, "voltage_nominal_v": 22.2, "mass_kg": 1.0},
+    )
+    assert "Short flight time" in out2
+
+    sys.modules["aerospace_mcp.integrations.propellers"] = make_module(
+        UAVConfiguration=UAV,
+        BatteryConfiguration=Bat,
+        uav_energy_estimate=lambda *a, **k: R3(),
+    )
+    out3 = uav(
+        {"wing_area_m2": 1.0},
+        {"capacity_ah": 10.0, "voltage_nominal_v": 22.2, "mass_kg": 1.0},
+    )
+    assert "Excellent endurance" in out3
+
+    # Multirotor branch (disk area)
+    class UAV2(UAV):
+        def __init__(self, **kw):
+            super().__init__(**kw)
+            self.wing_area_m2 = 0.0
+            self.disk_area_m2 = 2.0
+
+    sys.modules["aerospace_mcp.integrations.propellers"] = make_module(
+        UAVConfiguration=UAV2,
+        BatteryConfiguration=Bat,
+        uav_energy_estimate=lambda *a, **k: R2(),
+    )
+    out4 = uav(
+        {"disk_area_m2": 2.0},
+        {"capacity_ah": 10.0, "voltage_nominal_v": 22.2, "mass_kg": 1.0},
+    )
+    assert "Rotor Disk Area" in out4

--- a/tests/tools/test_tools_rockets.py
+++ b/tests/tools/test_tools_rockets.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sys
+
+from tests.tools.test_tools_common import (
+    StubPerf,
+    StubPoint,
+    make_module,
+)
+
+
+class RocketGeometry:
+    def __init__(self, **kwargs):
+        self.length_m = kwargs.get("length_m", 2.0)
+        self.diameter_m = kwargs.get("diameter_m", 0.3)
+        self.dry_mass_kg = kwargs.get("dry_mass_kg", 10.0)
+        self.propellant_mass_kg = kwargs.get("propellant_mass_kg", 5.0)
+
+
+def test_rocket_3dof_trajectory_success():
+    class Result:
+        performance = StubPerf()
+        trajectory = [
+            StubPoint(time_s=0, altitude_m=0, velocity_ms=0, acceleration_ms2=0),
+            StubPoint(time_s=10, altitude_m=100, velocity_ms=50, acceleration_ms2=5),
+        ]
+
+    def _traj(geometry, launch_conditions, sim_opts):
+        return Result()
+
+    sys.modules["aerospace_mcp.integrations.rockets"] = make_module(
+        RocketGeometry=RocketGeometry, rocket_3dof_trajectory=_traj
+    )
+
+    from aerospace_mcp.tools.rockets import rocket_3dof_trajectory
+
+    out = rocket_3dof_trajectory(
+        {
+            "length_m": 2.0,
+            "diameter_m": 0.2,
+            "dry_mass_kg": 10,
+            "propellant_mass_kg": 5,
+        },
+        {"launch_angle_deg": 80},
+        {},
+    )
+    assert "Rocket Trajectory" in out or "3DOF" in out
+
+
+def test_rocket_importerror():
+    import sys
+
+    from aerospace_mcp.tools import rockets as r_tools
+
+    sys.modules["aerospace_mcp.integrations.rockets"] = make_module()
+    assert "not available" in r_tools.rocket_3dof_trajectory({}, {}).lower()
+    assert "not available" in r_tools.estimate_rocket_sizing(1000, 5).lower()
+    assert (
+        "not available" in r_tools.optimize_launch_angle({}, None, "altitude").lower()
+    )
+
+
+def test_estimate_rocket_sizing_success():
+    import sys
+
+    sys.modules["aerospace_mcp.integrations.rockets"] = make_module(
+        estimate_rocket_sizing=lambda *a, **k: {"ok": True}
+    )
+    from aerospace_mcp.tools.rockets import estimate_rocket_sizing
+
+    out = estimate_rocket_sizing(1000, 5)
+    assert "ok" in out
+
+
+def test_optimize_launch_angle_success():
+    sys.modules["aerospace_mcp.integrations.rockets"] = make_module(
+        RocketGeometry=RocketGeometry,
+        optimize_launch_angle=lambda *a, **k: {"ok": True},
+    )
+    from aerospace_mcp.tools.rockets import optimize_launch_angle
+
+    out = optimize_launch_angle({"length_m": 2.0}, None, "altitude", (45.0, 90.0))
+    assert "ok" in out
+
+
+def test_rockets_exception_branches():
+    import sys
+
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    sys.modules["aerospace_mcp.integrations.rockets"] = make_module(
+        RocketGeometry=RocketGeometry,
+        rocket_3dof_trajectory=_boom,
+        estimate_rocket_sizing=_boom,
+        optimize_launch_angle=_boom,
+    )
+    from aerospace_mcp.tools.rockets import (
+        estimate_rocket_sizing as _size,
+    )
+    from aerospace_mcp.tools.rockets import (
+        optimize_launch_angle as _opt,
+    )
+    from aerospace_mcp.tools.rockets import (
+        rocket_3dof_trajectory as _traj,
+    )
+
+    assert "error" in _traj({}, {}).lower()
+    assert "error" in _size(1000, 5).lower()
+    assert "error" in _opt({}, None, "altitude").lower()


### PR DESCRIPTION
Add comprehensive unit tests for all aerospace_mcp/tools modules. Tests stub heavy integrations and cover success, ImportError, and exception branches to achieve 100% per-file coverage for tools, including core tools.