### PR TITLE
fix(agents): default to GPT-5.6 Sol, configurable via LLM_MODEL

### DIFF
--- a/aerospace_mcp/tools/agents.py
+++ b/aerospace_mcp/tools/agents.py
@@ -29,8 +29,8 @@ LLM_TOOLS_ENABLED = os.environ.get("LLM_TOOLS_ENABLED", "false").lower() == "tru
 litellm.set_verbose = False
 
 # Model used for agentic tool calls. Allow deployments to select any model
-# supported by LiteLLM while defaulting to OpenAI's current flagship alias.
-_AGENT_MODEL = os.environ.get("LLM_MODEL", "gpt-5.6")
+# supported by LiteLLM while defaulting to OpenAI's flagship model ID.
+_AGENT_MODEL = os.environ.get("LLM_MODEL", "gpt-5.6-sol")
 
 # Log status of LLM tools
 if not LLM_TOOLS_ENABLED:

--- a/aerospace_mcp/tools/agents.py
+++ b/aerospace_mcp/tools/agents.py
@@ -4,7 +4,7 @@ Provides LLM-powered assistant tools that help users:
 - Select the most appropriate aerospace-mcp tool for a given task.
 - Format input data correctly for a specific tool's expected schema.
 
-These tools use GPT-5-Medium via LiteLLM and require:
+These tools use a configurable LLM via LiteLLM and require:
 - LLM_TOOLS_ENABLED=true environment variable to be set.
 - OPENAI_API_KEY environment variable for API authentication.
 
@@ -25,12 +25,12 @@ logger = logging.getLogger(__name__)
 # Check if LLM tools are enabled via environment variable
 LLM_TOOLS_ENABLED = os.environ.get("LLM_TOOLS_ENABLED", "false").lower() == "true"
 
-# Configure LiteLLM for OpenAI GPT-5-Medium
+# Configure LiteLLM for agentic tool calls
 litellm.set_verbose = False
 
-# Model used for agentic tool calls. "gpt-5-medium" does not exist; default to a
-# real, widely-available model and allow override via the LLM_MODEL env var.
-_AGENT_MODEL = os.environ.get("LLM_MODEL", "gpt-4o")
+# Model used for agentic tool calls. Allow deployments to select any model
+# supported by LiteLLM while defaulting to OpenAI's current flagship alias.
+_AGENT_MODEL = os.environ.get("LLM_MODEL", "gpt-5.6")
 
 # Log status of LLM tools
 if not LLM_TOOLS_ENABLED:
@@ -189,7 +189,7 @@ def format_data_for_tool(
     """
     Help format data in the correct format for a specific aerospace-mcp tool.
 
-    Uses GPT-5-Medium to analyze the user's requirements and raw data, then provides
+    Uses the configured LLM to analyze the user's requirements and raw data, then provides
     the correctly formatted parameters for the specified tool.
 
     Args:
@@ -223,7 +223,7 @@ def format_data_for_tool(
     if "OPENAI_API_KEY" not in os.environ:
         return "Error: OPENAI_API_KEY environment variable not set. Cannot use agent tools."
 
-    # Build the prompt for GPT-5-Medium
+    # Build the formatting prompt
     system_prompt = f"""You are a data formatting assistant for aerospace-mcp tools. Your job is to help format data correctly for the '{tool_name}' tool.
 
 Tool Information:
@@ -241,7 +241,7 @@ Please provide ONLY a valid JSON object with the correctly formatted parameters 
 If the user's requirements are unclear or insufficient data is provided, return a JSON object with an "error" field explaining what additional information is needed."""
 
     try:
-        # Call GPT-5-Medium via LiteLLM
+        # Call the configured model via LiteLLM
         response = litellm.completion(
             model=_AGENT_MODEL,
             messages=[
@@ -272,7 +272,7 @@ def select_aerospace_tool(user_task: str, user_context: str = "") -> str:
     """
     Help select the most appropriate aerospace-mcp tool for a given task.
 
-    Uses GPT-5-Medium to analyze the user's task and recommend the best tool(s)
+    Uses the configured LLM to analyze the user's task and recommend the best tool(s)
     along with guidance on how to use them.
 
     Args:
@@ -330,7 +330,7 @@ Respond in a clear, structured format with:
 If the user's task cannot be accomplished with the available tools, clearly explain what's missing and suggest alternatives."""
 
     try:
-        # Call GPT-5-Medium via LiteLLM
+        # Call the configured model via LiteLLM
         response = litellm.completion(
             model=_AGENT_MODEL,
             messages=[

--- a/aerospace_mcp/tools/agents.py
+++ b/aerospace_mcp/tools/agents.py
@@ -28,6 +28,10 @@ LLM_TOOLS_ENABLED = os.environ.get("LLM_TOOLS_ENABLED", "false").lower() == "tru
 # Configure LiteLLM for OpenAI GPT-5-Medium
 litellm.set_verbose = False
 
+# Model used for agentic tool calls. "gpt-5-medium" does not exist; default to a
+# real, widely-available model and allow override via the LLM_MODEL env var.
+_AGENT_MODEL = os.environ.get("LLM_MODEL", "gpt-4o")
+
 # Log status of LLM tools
 if not LLM_TOOLS_ENABLED:
     logger.info("LLM tools disabled via LLM_TOOLS_ENABLED environment variable.")
@@ -239,7 +243,7 @@ If the user's requirements are unclear or insufficient data is provided, return 
     try:
         # Call GPT-5-Medium via LiteLLM
         response = litellm.completion(
-            model="gpt-5-medium",
+            model=_AGENT_MODEL,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {
@@ -328,7 +332,7 @@ If the user's task cannot be accomplished with the available tools, clearly expl
     try:
         # Call GPT-5-Medium via LiteLLM
         response = litellm.completion(
-            model="gpt-5-medium",
+            model=_AGENT_MODEL,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {

--- a/tests/tools/test_tools_agents.py
+++ b/tests/tools/test_tools_agents.py
@@ -59,6 +59,43 @@ def test_agents_success(monkeypatch):
     assert "search_airports" in out
 
 
+def test_agent_model_default_and_override(monkeypatch):
+    import importlib
+
+    import aerospace_mcp.tools.agents as agents
+
+    monkeypatch.setenv("LLM_TOOLS_ENABLED", "true")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    class Choice:
+        class Msg:
+            content = '{"tool": "search_airports"}'
+
+        message = Msg()
+
+    class Resp:
+        choices = [Choice()]
+
+    used_models = []
+
+    class StubLLM:
+        def completion(self, *a, **k):
+            used_models.append(k["model"])
+            return Resp()
+
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    importlib.reload(agents)
+    agents.litellm = StubLLM()  # type: ignore
+    agents.format_data_for_tool("search_airports", "Find airports")
+
+    monkeypatch.setenv("LLM_MODEL", "custom/provider-model")
+    importlib.reload(agents)
+    agents.litellm = StubLLM()  # type: ignore
+    agents.format_data_for_tool("search_airports", "Find airports")
+
+    assert used_models == ["gpt-5.6", "custom/provider-model"]
+
+
 def test_agents_exception_paths(monkeypatch):
     import importlib
 

--- a/tests/tools/test_tools_agents.py
+++ b/tests/tools/test_tools_agents.py
@@ -93,7 +93,7 @@ def test_agent_model_default_and_override(monkeypatch):
     agents.litellm = StubLLM()  # type: ignore
     agents.format_data_for_tool("search_airports", "Find airports")
 
-    assert used_models == ["gpt-5.6", "custom/provider-model"]
+    assert used_models == ["gpt-5.6-sol", "custom/provider-model"]
 
 
 def test_agents_exception_paths(monkeypatch):


### PR DESCRIPTION
## Summary

Replaces the non-existent `gpt-5-medium` model used by agentic tool calls with the explicit current OpenAI flagship model ID, `gpt-5.6-sol`, while preserving the `LLM_MODEL` environment-variable override for any LiteLLM-supported provider or model.

- Defaults both `litellm.completion` call sites to `gpt-5.6-sol`.
- Keeps deployments configurable through `LLM_MODEL`.
- Replaces stale GPT-5-Medium comments and docstrings with model-neutral wording.
- Adds regression coverage for both the default model and an environment override.

This keeps the focused integration fix from #11 without including its unrelated dependency, Python matrix, or Dockerfile changes.

## Validation

- `uv run pytest tests/tools/test_tools_agents.py` — 6 passed
- `uv run ruff check aerospace_mcp/tools/agents.py tests/tools/test_tools_agents.py`
- Pre-commit hooks passed during commit, including Ruff, formatting, and mypy.